### PR TITLE
Dev

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -497,6 +497,7 @@ if ($step == 3) {
 				'user_firstname' => \Input::post('firstname', 'Firstname'),
 				'user_email'     => \Input::post('email', ''),
 				'user_password'  => \Input::post('password', ''),
+				'user_last_connection'  => date('Y-m-d H:i:s'),
 			), true);
 
 			$user->save();


### PR DESCRIPTION
DB has user_last_connection column.

In my developement environment (all errors, including notices are displayed),
Error message says user_last_connection should not be NULL.

This code inserts user_last_connection to the time of user creation.
 'user_last_connection'  => date('Y-m-d H:i:s'),
