### PR TITLE
only PHP5.3 needs short_open_tag = ON

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -217,6 +217,7 @@ $tests = array(
         'passed'       => ini_get('short_open_tag') != false,
         'code'         => '# '.php_ini_loaded_file ()."\n<br />short_open_tag = On",
         'description'  => 'We use short_open_tag, since it\'ll be <a href="http://php.net/manual/en/ini.core.php#ini.short-open-tag">always enabled as of PHP 5.4</a>. Please edit your configuration file.',
+        'run_only_if'  => version_compare(PHP_VERSION,'5.4.0','<'),
     ),
 
     'folder.config.writeable' => array(


### PR DESCRIPTION
In PHP5.3, short_open_tag = ON is necessary.

In PHP5.4, as the manual says, 
http://php.net/manual/en/migration54.new-features.php
<?= is now always available, regardless of the short_open_tag php.ini option.

I'm sorry for incorrect suggestion on http://forums.novius-os.org/en/support-forums/contributions/short_open_tag-necessary,feed,58.html
