### PR TITLE
- Adding a config novius-os.cache for use of cache on front, by default ...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ Novius OS framework CHANGELOG
 - Standalone build of the wysiwyg renderer.
 - now inspectors key also allow class to be written
 - Refactor OS Tabs : if not a touch device, close icon now in tab with a context menu
+- Adding a config novius-os.cache for use of cache on front, by default true except in development
+- Setting configs novius-os.cache_duration_page and novius-os.cache_duration_function at 60 by default
+- Bugfix : controller front, POST and _preview use cache
 - Bugfix : front controller, getUrl now returns an absolute URL
 - Bugfix : popup for saving form answer attachment in media centre
 - Bugfix : media managing when not exist on disk

--- a/local/config/config.php.sample
+++ b/local/config/config.php.sample
@@ -22,6 +22,7 @@ return array(
     //'locale' => 'en_GB.utf8',
 
     //'novius-os' => array(
+        //'cache' => \Fuel::$env !== \Fuel::DEVELOPMENT,
         //'cache_duration_page' => 5,
         //'cache_duration_function' => 10,
 


### PR DESCRIPTION
...true except in development
- Setting configs novius-os.cache_duration_page and novius-os.cache_duration_function at 60 by default
- Bugfix : controller front, POST and _preview use cache
